### PR TITLE
fix: bump health-check UA to 1.1.1

### DIFF
--- a/scripts/health-check.py
+++ b/scripts/health-check.py
@@ -23,7 +23,7 @@ from collections import Counter
 
 TIMEOUT = 25
 DELAY = 0.4  # be a polite guest on other people's registries
-UA = "components-skill-health-check/1.0 (+https://github.com/AnayDhawan/Components)"
+UA = "components-skill-health-check/1.1.1 (+https://github.com/AnayDhawan/Components)"
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 # Upstream breakage that is already diagnosed and written up in


### PR DESCRIPTION
The user agent string in `scripts/health-check.py` was reporting version `1.0` while the actual project version is `1.1.1` (per `components.json`, `cli/package.json`, `gallery/package.json`, `CHANGELOG.md`). This fix updates the UA to match the current release version.